### PR TITLE
 Connection timeout issue for local user authentication when there are many parallel connections

### DIFF
--- a/base/src/main/java/com/instaclustr/cassandra/ldap/hash/HasherImpl.java
+++ b/base/src/main/java/com/instaclustr/cassandra/ldap/hash/HasherImpl.java
@@ -27,13 +27,13 @@ public class HasherImpl implements Hasher
     private static final Logger logger = LoggerFactory.getLogger(HasherImpl.class);
 
     @Override
-    public synchronized String hashPassword(String password, int rounds)
+    public String hashPassword(String password, int rounds)
     {
         return BCrypt.hashpw(password, BCrypt.gensalt(rounds));
     }
 
     @Override
-    public synchronized boolean checkPasswords(String plaintext, String hashed)
+    public boolean checkPasswords(String plaintext, String hashed)
     {
         try
         {


### PR DESCRIPTION
We experienced connection timeout issues for local user authentication, when there were many parallel connections, with LDAPAuthenticator. 

On further investigation, we found that the auth requests are not actually executing in parallel, as the methods on a static HasherImpl instance in LDAPAuthenticator were being synchronized. These methods need not be synchronized as there is no shared data that they are operating on. So, we removed synchronization, after which our auths started succeeding