### PR TITLE
Automatically Add LDAP Users to Role

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -20,12 +20,13 @@ depend. It contains core implementation which is necessary as all concrete modul
 The `base` module depends on Cassandra dependency—version 3.0.18 but its scope is `provided` as
 these classes will be present when such plugin as a whole is put on a class path of Cassandra in runtime.
 
-There are four implementation modules:
+There are five implementation modules:
 
 * cassandra-2.2 - builds against version 2.2.19
-* cassandra-3.0 - builds against version 3.0.25
-* cassandra-3.11 - builds against version 3.11.11
-* cassandra-4.0 - builds against version 4.0.0
+* cassandra-3.0 - builds against version 3.0.28
+* cassandra-3.11 - builds against version 3.11.14
+* cassandra-4.0 - builds against version 4.0.7
+* cassandra-4.1 - builds aganst version 4.1.0
 
 Project is built as:
 
@@ -89,6 +90,9 @@ The content of the configuration file is as follows:
 
 |load_ldap_service
 |defaults to false, if it is true, SPI mechanism will look on class path to load custom implementation of `LDAPUserRetriever`.
+
+|default_role_membership
+|A role to add new LDAP users to by default. Defaults to empty (users will not be added to any role).
 |===
 
 
@@ -122,15 +126,7 @@ role_manager: LDAPCassandraRoleManager
 authorizer: CassandraAuthorizer
 ```
 
-### Cassandra 3.11
-
-```
-authenticator: LDAPAuthenticator
-authorizer: CassandraAuthorizer
-role_manager: LDAPCassandraRoleManager
-```
-
-### Cassandra 4.0
+### Cassandra 3.11 - 4.x
 
 ```
 authenticator: LDAPAuthenticator
@@ -211,6 +207,14 @@ be just one line - the fully qualified class name (with package) of your custom 
 
 After you build such plugin, the SPI mechanism upon plugin's initialisation during Cassandra node startup
 will pick up your custom LDAP server connection / authentication logic.
+
+## Default Role Membership
+
+It is possible to automatically add new LDAP users to an existing Cassandra role when they are created by setting the
+`default_role_membership` configuration option. When this is set, any LDAP users logging in to Cassandra for the first
+time will be added to the role specified. Users who already exist in Cassandra will not be added to the group. If the
+default role specified does not exist, the role will not be created and new users will not receive the default membership.
+Only one role can be specified.
 
 ## Further Information
 - See blog by Stefan Miklosovic about https://www.instaclustr.com/the-instaclustr-ldap-plugin-for-cassandra/[Apache Cassandra LDAP Authentication]

--- a/base/src/main/java/com/instaclustr/cassandra/ldap/auth/SystemAuthRoles.java
+++ b/base/src/main/java/com/instaclustr/cassandra/ldap/auth/SystemAuthRoles.java
@@ -1,5 +1,7 @@
 package com.instaclustr.cassandra.ldap.auth;
 
+import java.util.Optional;
+
 import org.apache.cassandra.auth.LDAPCassandraRoleManager.Role;
 import org.apache.cassandra.db.ConsistencyLevel;
 import org.apache.cassandra.service.ClientState;
@@ -8,7 +10,7 @@ public interface SystemAuthRoles {
 
     boolean roleMissing(String dn);
 
-    void createRole(String roleName, boolean superUser);
+    void createRole(String roleName, boolean superUser, Optional<String> defaultRoleMembership);
 
     boolean hasAdminRole(String role);
 

--- a/base/src/main/java/com/instaclustr/cassandra/ldap/auth/SystemAuthRoles.java
+++ b/base/src/main/java/com/instaclustr/cassandra/ldap/auth/SystemAuthRoles.java
@@ -1,7 +1,5 @@
 package com.instaclustr.cassandra.ldap.auth;
 
-import java.util.Optional;
-
 import org.apache.cassandra.auth.LDAPCassandraRoleManager.Role;
 import org.apache.cassandra.db.ConsistencyLevel;
 import org.apache.cassandra.service.ClientState;
@@ -10,7 +8,7 @@ public interface SystemAuthRoles {
 
     boolean roleMissing(String dn);
 
-    void createRole(String roleName, boolean superUser, Optional<String> defaultRoleMembership);
+    void createRole(String roleName, boolean superUser, String defaultRoleMembership);
 
     boolean hasAdminRole(String role);
 

--- a/base/src/main/java/com/instaclustr/cassandra/ldap/conf/LdapAuthenticatorConfiguration.java
+++ b/base/src/main/java/com/instaclustr/cassandra/ldap/conf/LdapAuthenticatorConfiguration.java
@@ -63,6 +63,8 @@ public final class LdapAuthenticatorConfiguration
     public static final String CONSISTENCY_FOR_ROLE = "consistency_for_role";
     public static final String DEFAULT_CONSISTENCY_FOR_ROLE = "LOCAL_ONE";
 
+    public static final String DEFAULT_ROLE_MEMBERSHIP = "default_role_membership";
+
     public Properties parseProperties() throws ConfigurationException
     {
         Properties properties = new Properties();

--- a/base/src/main/java/org/apache/cassandra/auth/LDAPAuthenticator.java
+++ b/base/src/main/java/org/apache/cassandra/auth/LDAPAuthenticator.java
@@ -26,7 +26,6 @@ import static java.lang.String.format;
 
 import java.net.InetAddress;
 import java.util.concurrent.TimeUnit;
-import java.util.Optional;
 
 import com.google.common.util.concurrent.UncheckedExecutionException;
 import com.google.common.util.concurrent.Uninterruptibles;
@@ -162,7 +161,7 @@ public class LDAPAuthenticator extends AbstractLDAPAuthenticator
                 
                 if (cachedUser.getLdapDN() != null && systemAuthRoles.roleMissing(cachedUser.getLdapDN()))
                 {
-                    systemAuthRoles.createRole(cachedUser.getLdapDN(), false, Optional.ofNullable(properties.getProperty(DEFAULT_ROLE_MEMBERSHIP, null)));
+                    systemAuthRoles.createRole(cachedUser.getLdapDN(), false, properties.getProperty(DEFAULT_ROLE_MEMBERSHIP, null));
                 }
 
                 final String loginName = cachedUser.getLdapDN() == null ? cachedUser.getUsername() : cachedUser.getLdapDN();

--- a/base/src/main/java/org/apache/cassandra/auth/LDAPAuthenticator.java
+++ b/base/src/main/java/org/apache/cassandra/auth/LDAPAuthenticator.java
@@ -19,12 +19,14 @@ package org.apache.cassandra.auth;
 
 import static com.instaclustr.cassandra.ldap.conf.LdapAuthenticatorConfiguration.CASSANDRA_AUTH_CACHE_ENABLED_PROP;
 import static com.instaclustr.cassandra.ldap.conf.LdapAuthenticatorConfiguration.CASSANDRA_LDAP_ADMIN_USER;
+import static com.instaclustr.cassandra.ldap.conf.LdapAuthenticatorConfiguration.DEFAULT_ROLE_MEMBERSHIP;
 import static com.instaclustr.cassandra.ldap.utils.ServiceUtils.getService;
 import static java.lang.Boolean.parseBoolean;
 import static java.lang.String.format;
 
 import java.net.InetAddress;
 import java.util.concurrent.TimeUnit;
+import java.util.Optional;
 
 import com.google.common.util.concurrent.UncheckedExecutionException;
 import com.google.common.util.concurrent.Uninterruptibles;
@@ -157,11 +159,10 @@ public class LDAPAuthenticator extends AbstractLDAPAuthenticator
                     cacheDelegate.invalidate(user);
                     cacheDelegate.get(user);
                 }
-
-
+                
                 if (cachedUser.getLdapDN() != null && systemAuthRoles.roleMissing(cachedUser.getLdapDN()))
                 {
-                    systemAuthRoles.createRole(cachedUser.getLdapDN(), false);
+                    systemAuthRoles.createRole(cachedUser.getLdapDN(), false, Optional.ofNullable(properties.getProperty(DEFAULT_ROLE_MEMBERSHIP, null)));
                 }
 
                 final String loginName = cachedUser.getLdapDN() == null ? cachedUser.getUsername() : cachedUser.getLdapDN();

--- a/base/src/main/java/org/apache/cassandra/auth/LDAPCassandraRoleManager.java
+++ b/base/src/main/java/org/apache/cassandra/auth/LDAPCassandraRoleManager.java
@@ -23,7 +23,6 @@ import static com.instaclustr.cassandra.ldap.conf.LdapAuthenticatorConfiguration
 import static com.instaclustr.cassandra.ldap.conf.LdapAuthenticatorConfiguration.LDAP_DN;
 import static java.lang.String.format;
 
-import java.util.Optional;
 import java.util.Properties;
 import java.util.Set;
 import java.util.StringJoiner;
@@ -119,7 +118,7 @@ public class LDAPCassandraRoleManager extends CassandraRoleManager
                 {
                     if (systemAuthRoles.roleMissing(ldapAdminRole))
                     {
-                        systemAuthRoles.createRole(ldapAdminRole, true, Optional.empty());
+                        systemAuthRoles.createRole(ldapAdminRole, true, null);
                         logger.info("Created LDAP admin role '{}'", ldapAdminRole);
                     } else
                     {

--- a/base/src/main/java/org/apache/cassandra/auth/LDAPCassandraRoleManager.java
+++ b/base/src/main/java/org/apache/cassandra/auth/LDAPCassandraRoleManager.java
@@ -23,6 +23,7 @@ import static com.instaclustr.cassandra.ldap.conf.LdapAuthenticatorConfiguration
 import static com.instaclustr.cassandra.ldap.conf.LdapAuthenticatorConfiguration.LDAP_DN;
 import static java.lang.String.format;
 
+import java.util.Optional;
 import java.util.Properties;
 import java.util.Set;
 import java.util.StringJoiner;
@@ -118,7 +119,7 @@ public class LDAPCassandraRoleManager extends CassandraRoleManager
                 {
                     if (systemAuthRoles.roleMissing(ldapAdminRole))
                     {
-                        systemAuthRoles.createRole(ldapAdminRole, true);
+                        systemAuthRoles.createRole(ldapAdminRole, true, Optional.empty());
                         logger.info("Created LDAP admin role '{}'", ldapAdminRole);
                     } else
                     {

--- a/base/src/main/java/org/apache/cassandra/auth/LegacyCassandraLDAPAuthenticator.java
+++ b/base/src/main/java/org/apache/cassandra/auth/LegacyCassandraLDAPAuthenticator.java
@@ -18,10 +18,12 @@
 package org.apache.cassandra.auth;
 
 import static com.instaclustr.cassandra.ldap.conf.LdapAuthenticatorConfiguration.CASSANDRA_LDAP_ADMIN_USER;
+import static com.instaclustr.cassandra.ldap.conf.LdapAuthenticatorConfiguration.DEFAULT_ROLE_MEMBERSHIP;
 import static com.instaclustr.cassandra.ldap.utils.ServiceUtils.getService;
 import static java.lang.String.format;
 
 import java.util.concurrent.TimeUnit;
+import java.util.Optional;
 
 import com.google.common.util.concurrent.UncheckedExecutionException;
 import com.google.common.util.concurrent.Uninterruptibles;
@@ -117,7 +119,7 @@ public abstract class LegacyCassandraLDAPAuthenticator extends AbstractLDAPAuthe
 
                 if (retrievedUser.getLdapDN() != null && systemAuthRoles.roleMissing(retrievedUser.getLdapDN()))
                 {
-                    systemAuthRoles.createRole(retrievedUser.getLdapDN(), false);
+                    systemAuthRoles.createRole(retrievedUser.getLdapDN(), false, Optional.ofNullable(properties.getProperty(DEFAULT_ROLE_MEMBERSHIP, null)));
                 }
 
                 final String loginName = retrievedUser.getLdapDN() == null ? retrievedUser.getUsername() : retrievedUser.getLdapDN();

--- a/base/src/main/java/org/apache/cassandra/auth/LegacyCassandraLDAPAuthenticator.java
+++ b/base/src/main/java/org/apache/cassandra/auth/LegacyCassandraLDAPAuthenticator.java
@@ -23,7 +23,6 @@ import static com.instaclustr.cassandra.ldap.utils.ServiceUtils.getService;
 import static java.lang.String.format;
 
 import java.util.concurrent.TimeUnit;
-import java.util.Optional;
 
 import com.google.common.util.concurrent.UncheckedExecutionException;
 import com.google.common.util.concurrent.Uninterruptibles;
@@ -119,7 +118,7 @@ public abstract class LegacyCassandraLDAPAuthenticator extends AbstractLDAPAuthe
 
                 if (retrievedUser.getLdapDN() != null && systemAuthRoles.roleMissing(retrievedUser.getLdapDN()))
                 {
-                    systemAuthRoles.createRole(retrievedUser.getLdapDN(), false, Optional.ofNullable(properties.getProperty(DEFAULT_ROLE_MEMBERSHIP, null)));
+                    systemAuthRoles.createRole(retrievedUser.getLdapDN(), false, properties.getProperty(DEFAULT_ROLE_MEMBERSHIP, null));
                 }
 
                 final String loginName = retrievedUser.getLdapDN() == null ? retrievedUser.getUsername() : retrievedUser.getLdapDN();

--- a/build.sh
+++ b/build.sh
@@ -2,6 +2,7 @@
 
 mvn clean install \
   -Dversion.cassandra22=2.2.19 \
-  -Dversion.cassandra30=3.0.25 \
-  -Dversion.cassandra311=3.11.11 \
-  -Dversion.cassandra4=4.0.0
+  -Dversion.cassandra30=3.0.28 \
+  -Dversion.cassandra311=3.11.14 \
+  -Dversion.cassandra4=4.0.7 \
+  -Dversion.cassandra41=4.1.0

--- a/cassandra-2.2/pom.xml
+++ b/cassandra-2.2/pom.xml
@@ -11,7 +11,7 @@
     </parent>
 
     <artifactId>cassandra-ldap-2.2.19</artifactId>
-    <version>1.0.2</version>
+    <version>1.1.0</version>
 
     <name>Cassandra LDAP Authenticator for Cassandra 2.2</name>
     <description>Pluggable LDAP authentication implementation for Apache Cassandra 2.2</description>

--- a/cassandra-2.2/src/main/java/org/apache/cassandra/auth/Cassandra22SystemAuthRoles.java
+++ b/cassandra-2.2/src/main/java/org/apache/cassandra/auth/Cassandra22SystemAuthRoles.java
@@ -5,7 +5,6 @@ import static java.util.Collections.singletonList;
 import static org.apache.cassandra.db.ConsistencyLevel.LOCAL_ONE;
 
 import java.util.Collections;
-import java.util.Optional;
 import java.util.function.Function;
 
 import com.instaclustr.cassandra.ldap.auth.SystemAuthRoles;
@@ -64,7 +63,7 @@ public class Cassandra22SystemAuthRoles implements SystemAuthRoles {
         return rows.result.isEmpty();
     }
 
-    public void createRole(String roleName, boolean superUser, Optional<String> defaultRoleMembership)
+    public void createRole(String roleName, boolean superUser, String defaultRoleMembership)
     {
         final CreateRoleStatement createStmt = (CreateRoleStatement) QueryProcessor.getStatement(format(CREATE_ROLE_STATEMENT_WITH_LOGIN, roleName, superUser),
                                                                                                  getClientState()).statement;
@@ -72,13 +71,17 @@ public class Cassandra22SystemAuthRoles implements SystemAuthRoles {
         createStmt.execute(new QueryState(getClientState()),
                            QueryOptions.forInternalCalls(LOCAL_ONE, singletonList(ByteBufferUtil.bytes(roleName))));
 
-        if (defaultRoleMembership.isPresent()) {
-            if (roleMissing(defaultRoleMembership.get())) {
-                logger.warn("Unable to add user to default role {} because it doesn't exist.", defaultRoleMembership.get());
-            } else {
-                logger.debug("Adding user {} to default role {}", roleName, defaultRoleMembership.get());
+        if (defaultRoleMembership != null)
+        {
+            if (roleMissing(defaultRoleMembership))
+            {
+                logger.warn("Unable to add user to default role {} because it doesn't exist.", defaultRoleMembership);
+            }
+            else
+            {
+                logger.debug("Adding user {} to default role {}", roleName, defaultRoleMembership);
                 final GrantRoleStatement grantRoleStmt = (GrantRoleStatement) QueryProcessor.getStatement(format(GRANT_ROLE_STATEMENT,
-                                                                                                                 defaultRoleMembership.get(),
+                                                                                                                 defaultRoleMembership,
                                                                                                                  roleName),
                                                                                                           getClientState()).statement;
 

--- a/cassandra-2.2/src/main/java/org/apache/cassandra/auth/Cassandra22SystemAuthRoles.java
+++ b/cassandra-2.2/src/main/java/org/apache/cassandra/auth/Cassandra22SystemAuthRoles.java
@@ -5,6 +5,7 @@ import static java.util.Collections.singletonList;
 import static org.apache.cassandra.db.ConsistencyLevel.LOCAL_ONE;
 
 import java.util.Collections;
+import java.util.Optional;
 import java.util.function.Function;
 
 import com.instaclustr.cassandra.ldap.auth.SystemAuthRoles;
@@ -15,6 +16,7 @@ import org.apache.cassandra.cql3.QueryProcessor;
 import org.apache.cassandra.cql3.UntypedResultSet;
 import org.apache.cassandra.cql3.UntypedResultSet.Row;
 import org.apache.cassandra.cql3.statements.CreateRoleStatement;
+import org.apache.cassandra.cql3.statements.GrantRoleStatement;
 import org.apache.cassandra.cql3.statements.SelectStatement;
 import org.apache.cassandra.db.ConsistencyLevel;
 import org.apache.cassandra.db.marshal.UTF8Type;
@@ -34,6 +36,8 @@ public class Cassandra22SystemAuthRoles implements SystemAuthRoles {
     public static final String SELECT_ROLE_STATEMENT = "SELECT role FROM %s.%s where role = ?";
 
     public static final String CREATE_ROLE_STATEMENT_WITH_LOGIN = "CREATE ROLE IF NOT EXISTS \"%s\" WITH LOGIN = true AND SUPERUSER = %s";
+
+    public static final String GRANT_ROLE_STATEMENT = "GRANT '%s' TO '%s'";
 
     private ClientState clientState;
 
@@ -60,13 +64,28 @@ public class Cassandra22SystemAuthRoles implements SystemAuthRoles {
         return rows.result.isEmpty();
     }
 
-    public void createRole(String roleName, boolean superUser)
+    public void createRole(String roleName, boolean superUser, Optional<String> defaultRoleMembership)
     {
         final CreateRoleStatement createStmt = (CreateRoleStatement) QueryProcessor.getStatement(format(CREATE_ROLE_STATEMENT_WITH_LOGIN, roleName, superUser),
                                                                                                  getClientState()).statement;
 
         createStmt.execute(new QueryState(getClientState()),
                            QueryOptions.forInternalCalls(LOCAL_ONE, singletonList(ByteBufferUtil.bytes(roleName))));
+
+        if (defaultRoleMembership.isPresent()) {
+            if (roleMissing(defaultRoleMembership.get())) {
+                logger.warn("Unable to add user to default role {} because it doesn't exist.", defaultRoleMembership.get());
+            } else {
+                logger.debug("Adding user {} to default role {}", roleName, defaultRoleMembership.get());
+                final GrantRoleStatement grantRoleStmt = (GrantRoleStatement) QueryProcessor.getStatement(format(GRANT_ROLE_STATEMENT,
+                                                                                                                 defaultRoleMembership.get(),
+                                                                                                                 roleName),
+                                                                                                          getClientState()).statement;
+
+                grantRoleStmt.execute(new QueryState(getClientState()),
+                                      QueryOptions.forInternalCalls(LOCAL_ONE, singletonList(ByteBufferUtil.bytes(roleName))));
+            }
+        }
     }
 
     public boolean hasAdminRole(String role) throws RequestExecutionException

--- a/cassandra-2.2/src/test/java/com/instaclustr/cassandra/ldap/auth/AbstractLDAPTest.java
+++ b/cassandra-2.2/src/test/java/com/instaclustr/cassandra/ldap/auth/AbstractLDAPTest.java
@@ -59,6 +59,14 @@ import static org.testng.Assert.*;
 public abstract class AbstractLDAPTest {
 
     private static final Logger logger = LoggerFactory.getLogger(AbstractLDAPTest.class);
+    private static final String cassandraAdminUser = "cassandra";
+    private static final String cassandraAdminPassword = "cassandra";
+    private static final String cassandraDataCenter1 = "datacenter1";
+    private static final String testUserName = "bill";
+    private static final String testUserPassword = "test";
+    private static final String testUserDn = "cn=bill,dc=example,dc=org";
+    private static final String defaultRoleName = "default_role";
+    private static final String basicQuery = "SELECT * FROM system.local;";
 
     protected void testLDAPinternal() throws Exception {
         try (final GenericContainer ldapContainer = prepareLdapContainer();
@@ -67,22 +75,64 @@ public abstract class AbstractLDAPTest {
             context.start();
 
             context.execute(context.firstNode,
-                    "cassandra",
-                    "cassandra",
-                    "ALTER KEYSPACE system_auth WITH replication = {'class': 'NetworkTopologyStrategy', 'datacenter1': 1, 'datacenter2':1};", "datacenter1", false);
+            cassandraAdminUser,
+            cassandraAdminPassword,
+                    "ALTER KEYSPACE system_auth WITH replication = {'class': 'NetworkTopologyStrategy', 'datacenter1': 1, 'datacenter2':1};", cassandraDataCenter1, false);
 
             Thread.sleep(5000);
 
             logger.info("[first node]: login via cassandra");
-            context.execute(context.firstNode, "cassandra", "cassandra", "select * from system_auth.roles", "datacenter1", true);
+            context.execute(context.firstNode, cassandraAdminUser, cassandraAdminPassword, "select * from system_auth.roles", cassandraDataCenter1, true);
             logger.info("[first node]: login bill");
-            context.execute(context.firstNode, "bill", "test", "select * from system.local", "datacenter1", true);
+            context.execute(context.firstNode, testUserName, testUserPassword, basicQuery, cassandraDataCenter1, true);
 
             logger.info("[second node]: login bill");
-            context.execute(context.secondNode, "bill", "test", "select * from system.local", "datacenter2", true);
+            context.execute(context.secondNode, testUserName, testUserPassword, basicQuery, "datacenter2", true);
+
+            testDefaultRoleMembership(ldapContainer, context);
         } catch (final Exception ex) {
             fail("Exception occurred!", ex);
         }
+    }
+
+    protected void testDefaultRoleMembership(GenericContainer ldapContainer, CassandraClusterContext context) throws Exception {
+        // Create the default role
+        context.simpleExecute(
+            context.firstNode,
+            cassandraAdminUser,
+            cassandraAdminPassword,
+            String.format("CREATE ROLE '%s';", defaultRoleName),
+            cassandraDataCenter1
+        );
+
+        // Delete the user if it already exists
+        context.simpleExecute(
+            context.firstNode,
+            cassandraAdminUser,
+            cassandraAdminPassword,
+            String.format("DROP ROLE IF EXISTS '%s';", testUserDn),
+            cassandraDataCenter1
+        );
+
+        // Simulate a Logon as the user
+        context.simpleExecute(
+            context.firstNode,
+            testUserName,
+            testUserPassword,
+            basicQuery,
+            cassandraDataCenter1
+        );
+
+        // Check that the default role has been added to the user
+        assertTrue(
+            context.simpleExecute(
+                context.firstNode,
+                cassandraAdminUser,
+                cassandraAdminPassword,
+                String.format("LIST ROLES OF '%s';", testUserDn),
+                cassandraDataCenter1
+            ).all().stream().anyMatch(row -> row.getString("role").equals(defaultRoleName))
+        );
     }
 
     public abstract String getCassandraVersion();
@@ -130,6 +180,22 @@ public abstract class AbstractLDAPTest {
                                          String dc,
                                          boolean check) {
             execute(node.getSettings().getAddress(), username, password, query, dc, check);
+        }
+        
+        public synchronized ResultSet simpleExecute(
+            Cassandra node,
+            String username,
+            String password,
+            String query,
+            String dc
+        ) {
+            try (final Session session = Cluster.builder()
+                    .addContactPoint(node.getSettings().getAddress().getHostAddress())
+                    .withLoadBalancingPolicy(new DCAwareRoundRobinPolicy.Builder().withLocalDc(dc).build())
+                    .withAuthProvider(new PlainTextAuthProvider(username, password))
+                    .build().connect()) {
+                return session.execute(query);
+            }
         }
 
         public synchronized void execute(InetAddress point,

--- a/cassandra-2.2/src/test/java/com/instaclustr/cassandra/ldap/auth/AbstractLDAPTest.java
+++ b/cassandra-2.2/src/test/java/com/instaclustr/cassandra/ldap/auth/AbstractLDAPTest.java
@@ -75,8 +75,8 @@ public abstract class AbstractLDAPTest {
             context.start();
 
             context.execute(context.firstNode,
-            cassandraAdminUser,
-            cassandraAdminPassword,
+                    cassandraAdminUser,
+                    cassandraAdminPassword,
                     "ALTER KEYSPACE system_auth WITH replication = {'class': 'NetworkTopologyStrategy', 'datacenter1': 1, 'datacenter2':1};", cassandraDataCenter1, false);
 
             Thread.sleep(5000);

--- a/cassandra-2.2/src/test/java/com/instaclustr/cassandra/ldap/auth/AbstractLDAPTest.java
+++ b/cassandra-2.2/src/test/java/com/instaclustr/cassandra/ldap/auth/AbstractLDAPTest.java
@@ -183,13 +183,12 @@ public abstract class AbstractLDAPTest {
             execute(node.getSettings().getAddress(), username, password, query, dc, check);
         }
         
-        public synchronized ResultSet simpleExecute(
-            Cassandra node,
-            String username,
-            String password,
-            String query,
-            String dc
-        ) {
+        public synchronized ResultSet simpleExecute(Cassandra node,
+                                                    String username,
+                                                    String password,
+                                                    String query,
+                                                    String dc)
+        {
             try (final Session session = Cluster.builder()
                     .addContactPoint(node.getSettings().getAddress().getHostAddress())
                     .withLoadBalancingPolicy(new DCAwareRoundRobinPolicy.Builder().withLocalDc(dc).build())

--- a/cassandra-2.2/src/test/java/com/instaclustr/cassandra/ldap/auth/AbstractLDAPTest.java
+++ b/cassandra-2.2/src/test/java/com/instaclustr/cassandra/ldap/auth/AbstractLDAPTest.java
@@ -95,7 +95,8 @@ public abstract class AbstractLDAPTest {
         }
     }
 
-    protected void testDefaultRoleMembership(GenericContainer ldapContainer, CassandraClusterContext context) throws Exception {
+    protected void testDefaultRoleMembership(GenericContainer ldapContainer, CassandraClusterContext context) throws Exception
+    {
         // Create the default role
         context.simpleExecute(
             context.firstNode,

--- a/cassandra-2.2/src/test/java/com/instaclustr/cassandra/ldap/auth/Cassandra22LDAPIntegrationTest.java
+++ b/cassandra-2.2/src/test/java/com/instaclustr/cassandra/ldap/auth/Cassandra22LDAPIntegrationTest.java
@@ -10,7 +10,7 @@ public class Cassandra22LDAPIntegrationTest extends AbstractLDAPTest {
 
     @Override
     public String getImplementationGAV() {
-        return "com.instaclustr:cassandra-ldap-" + getCassandraVersion() + ":1.0.2";
+        return "com.instaclustr:cassandra-ldap-" + getCassandraVersion() + ":1.1.0";
     }
 
     @Test

--- a/cassandra-3.0/pom.xml
+++ b/cassandra-3.0/pom.xml
@@ -11,7 +11,7 @@
     </parent>
 
     <artifactId>cassandra-ldap-3.0.28</artifactId>
-    <version>1.0.0</version>
+    <version>1.1.0</version>
 
     <name>Cassandra LDAP Authenticator for Cassandra 3.0</name>
     <description>Pluggable LDAP authentication implementation for Apache Cassandra 3.0</description>

--- a/cassandra-3.0/src/main/java/org/apache/cassandra/auth/Cassandra30SystemAuthRoles.java
+++ b/cassandra-3.0/src/main/java/org/apache/cassandra/auth/Cassandra30SystemAuthRoles.java
@@ -5,6 +5,7 @@ import static java.util.Collections.singletonList;
 import static org.apache.cassandra.db.ConsistencyLevel.LOCAL_ONE;
 
 import java.util.Collections;
+import java.util.Optional;
 import java.util.function.Function;
 
 import com.instaclustr.cassandra.ldap.auth.SystemAuthRoles;
@@ -16,6 +17,7 @@ import org.apache.cassandra.cql3.UntypedResultSet;
 import org.apache.cassandra.cql3.UntypedResultSet.Row;
 import org.apache.cassandra.cql3.statements.CreateRoleStatement;
 import org.apache.cassandra.cql3.statements.SelectStatement;
+import org.apache.cassandra.cql3.statements.GrantRoleStatement;
 import org.apache.cassandra.db.ConsistencyLevel;
 import org.apache.cassandra.db.marshal.UTF8Type;
 import org.apache.cassandra.exceptions.RequestExecutionException;
@@ -34,6 +36,8 @@ public class Cassandra30SystemAuthRoles implements SystemAuthRoles {
     public static final String SELECT_ROLE_STATEMENT = "SELECT role FROM %s.%s where role = ?";
 
     public static final String CREATE_ROLE_STATEMENT_WITH_LOGIN = "CREATE ROLE IF NOT EXISTS \"%s\" WITH LOGIN = true AND SUPERUSER = %s";
+
+    public static final String GRANT_ROLE_STATEMENT = "GRANT '%s' TO '%s'";
 
     private ClientState clientState;
 
@@ -60,13 +64,28 @@ public class Cassandra30SystemAuthRoles implements SystemAuthRoles {
         return rows.result.isEmpty();
     }
 
-    public void createRole(String roleName, boolean superUser)
+    public void createRole(String roleName, boolean superUser, Optional<String> defaultRoleMembership)
     {
         final CreateRoleStatement createStmt = (CreateRoleStatement) QueryProcessor.getStatement(format(CREATE_ROLE_STATEMENT_WITH_LOGIN, roleName, superUser),
                                                                                                  getClientState()).statement;
 
         createStmt.execute(new QueryState(getClientState()),
                            QueryOptions.forInternalCalls(LOCAL_ONE, singletonList(ByteBufferUtil.bytes(roleName))));
+
+        if (defaultRoleMembership.isPresent()) {
+            if (roleMissing(defaultRoleMembership.get())) {
+                logger.warn("Unable to add user to default role {} because it doesn't exist.", defaultRoleMembership.get());
+            } else {
+                logger.debug("Adding user {} to default role {}", roleName, defaultRoleMembership.get());
+                final GrantRoleStatement grantRoleStmt = (GrantRoleStatement) QueryProcessor.getStatement(format(GRANT_ROLE_STATEMENT,
+                                                                                                                 defaultRoleMembership.get(),
+                                                                                                                 roleName),
+                                                                                                          getClientState()).statement;
+
+                grantRoleStmt.execute(new QueryState(getClientState()),
+                                      QueryOptions.forInternalCalls(LOCAL_ONE, singletonList(ByteBufferUtil.bytes(roleName))));
+            }
+        }
     }
 
     public boolean hasAdminRole(String role) throws RequestExecutionException

--- a/cassandra-3.0/src/test/java/com/instaclustr/cassandra/ldap/auth/AbstractLDAPTest.java
+++ b/cassandra-3.0/src/test/java/com/instaclustr/cassandra/ldap/auth/AbstractLDAPTest.java
@@ -56,6 +56,14 @@ import static org.testng.Assert.*;
 public abstract class AbstractLDAPTest {
 
     private static final Logger logger = LoggerFactory.getLogger(AbstractLDAPTest.class);
+    private static final String cassandraAdminUser = "cassandra";
+    private static final String cassandraAdminPassword = "cassandra";
+    private static final String cassandraDataCenter1 = "datacenter1";
+    private static final String testUserName = "bill";
+    private static final String testUserPassword = "test";
+    private static final String testUserDn = "cn=bill,dc=example,dc=org";
+    private static final String defaultRoleName = "default_role";
+    private static final String basicQuery = "SELECT * FROM system.local;";
 
     protected void testLDAPinternal() throws Exception {
         try (final GenericContainer ldapContainer = prepareLdapContainer();
@@ -64,20 +72,62 @@ public abstract class AbstractLDAPTest {
             context.start();
 
             context.execute(context.firstNode,
-                    "cassandra",
-                    "cassandra",
-                    "ALTER KEYSPACE system_auth WITH replication = {'class': 'NetworkTopologyStrategy', 'datacenter1': 1, 'datacenter2':1};", "datacenter1", false);
+                    cassandraAdminUser,
+                    cassandraAdminPassword,
+                    "ALTER KEYSPACE system_auth WITH replication = {'class': 'NetworkTopologyStrategy', 'datacenter1': 1, 'datacenter2':1};", cassandraDataCenter1, false);
 
             logger.info("[first node]: login via cassandra");
-            context.execute(context.firstNode, "cassandra", "cassandra", "select * from system_auth.roles", "datacenter1", true);
+            context.execute(context.firstNode, cassandraAdminUser, cassandraAdminPassword, "select * from system_auth.roles", cassandraDataCenter1, true);
             logger.info("[first node]: login bill");
-            context.execute(context.firstNode, "bill", "test", "select * from system.local", "datacenter1", true);
+            context.execute(context.firstNode, testUserName, testUserPassword, basicQuery, cassandraDataCenter1, true);
 
             logger.info("[second node]: login bill");
-            context.execute(context.secondNode, "bill", "test", "select * from system.local", "datacenter2", true);
+            context.execute(context.secondNode, testUserName, testUserPassword, basicQuery, "datacenter2", true);
+
+            testDefaultRoleMembership(ldapContainer, context);
         } catch (final Exception ex) {
             fail("Exception occurred!", ex);
         }
+    }
+
+    protected void testDefaultRoleMembership(GenericContainer ldapContainer, CassandraClusterContext context) throws Exception {
+        // Create the default role
+        context.simpleExecute(
+            context.firstNode,
+            cassandraAdminUser,
+            cassandraAdminPassword,
+            String.format("CREATE ROLE '%s';", defaultRoleName),
+            cassandraDataCenter1
+        );
+
+        // Delete the user if it already exists
+        context.simpleExecute(
+            context.firstNode,
+            cassandraAdminUser,
+            cassandraAdminPassword,
+            String.format("DROP ROLE IF EXISTS '%s';", testUserDn),
+            cassandraDataCenter1
+        );
+
+        // Simulate a Logon as the user
+        context.simpleExecute(
+            context.firstNode,
+            testUserName,
+            testUserPassword,
+            basicQuery,
+            cassandraDataCenter1
+        );
+
+        // Check that the default role has been added to the user
+        assertTrue(
+            context.simpleExecute(
+                context.firstNode,
+                cassandraAdminUser,
+                cassandraAdminPassword,
+                String.format("LIST ROLES OF '%s';", testUserDn),
+                cassandraDataCenter1
+            ).all().stream().anyMatch(row -> row.getString("role").equals(defaultRoleName))
+        );
     }
 
     public abstract String getCassandraVersion();
@@ -125,6 +175,22 @@ public abstract class AbstractLDAPTest {
                                          String dc,
                                          boolean check) {
             execute(node.getSettings().getAddress(), username, password, query, dc, check);
+        }
+
+        public synchronized ResultSet simpleExecute(
+            Cassandra node,
+            String username,
+            String password,
+            String query,
+            String dc
+        ) {
+            try (final Session session = Cluster.builder()
+                    .addContactPoint(node.getSettings().getAddress().getHostAddress())
+                    .withLoadBalancingPolicy(new DCAwareRoundRobinPolicy.Builder().withLocalDc(dc).build())
+                    .withAuthProvider(new PlainTextAuthProvider(username, password))
+                    .build().connect()) {
+                return session.execute(query);
+            }
         }
 
         public synchronized void execute(InetAddress point,

--- a/cassandra-3.0/src/test/java/com/instaclustr/cassandra/ldap/auth/AbstractLDAPTest.java
+++ b/cassandra-3.0/src/test/java/com/instaclustr/cassandra/ldap/auth/AbstractLDAPTest.java
@@ -178,13 +178,12 @@ public abstract class AbstractLDAPTest {
             execute(node.getSettings().getAddress(), username, password, query, dc, check);
         }
 
-        public synchronized ResultSet simpleExecute(
-            Cassandra node,
-            String username,
-            String password,
-            String query,
-            String dc
-        ) {
+        public synchronized ResultSet simpleExecute(Cassandra node,
+                                                    String username,
+                                                    String password,
+                                                    String query,
+                                                    String dc)
+        {
             try (final Session session = Cluster.builder()
                     .addContactPoint(node.getSettings().getAddress().getHostAddress())
                     .withLoadBalancingPolicy(new DCAwareRoundRobinPolicy.Builder().withLocalDc(dc).build())

--- a/cassandra-3.0/src/test/java/com/instaclustr/cassandra/ldap/auth/AbstractLDAPTest.java
+++ b/cassandra-3.0/src/test/java/com/instaclustr/cassandra/ldap/auth/AbstractLDAPTest.java
@@ -90,7 +90,8 @@ public abstract class AbstractLDAPTest {
         }
     }
 
-    protected void testDefaultRoleMembership(GenericContainer ldapContainer, CassandraClusterContext context) throws Exception {
+    protected void testDefaultRoleMembership(GenericContainer ldapContainer, CassandraClusterContext context) throws Exception
+    {
         // Create the default role
         context.simpleExecute(
             context.firstNode,

--- a/cassandra-3.0/src/test/java/com/instaclustr/cassandra/ldap/auth/Cassandra30LDAPIntegrationTest.java
+++ b/cassandra-3.0/src/test/java/com/instaclustr/cassandra/ldap/auth/Cassandra30LDAPIntegrationTest.java
@@ -10,7 +10,7 @@ public class Cassandra30LDAPIntegrationTest extends AbstractLDAPTest {
 
     @Override
     public String getImplementationGAV() {
-        return "com.instaclustr:cassandra-ldap-" + getCassandraVersion() + ":1.0.0";
+        return "com.instaclustr:cassandra-ldap-" + getCassandraVersion() + ":1.1.0";
     }
 
     @Test

--- a/cassandra-3.11/pom.xml
+++ b/cassandra-3.11/pom.xml
@@ -11,7 +11,7 @@
     </parent>
 
     <artifactId>cassandra-ldap-3.11.14</artifactId>
-    <version>1.0.0</version>
+    <version>1.1.0</version>
 
     <name>Cassandra LDAP Authenticator for Cassandra 3.11</name>
     <description>Pluggable LDAP authentication implementation for Apache Cassandra 3.11</description>

--- a/cassandra-3.11/src/main/java/com/instaclustr/cassandra/ldap/auth/Cassandra311SystemAuthRoles.java
+++ b/cassandra-3.11/src/main/java/com/instaclustr/cassandra/ldap/auth/Cassandra311SystemAuthRoles.java
@@ -22,7 +22,6 @@ import static java.util.Collections.singletonList;
 import static org.apache.cassandra.db.ConsistencyLevel.LOCAL_ONE;
 
 import java.util.Collections;
-import java.util.Optional;
 
 import com.google.common.base.Function;
 import org.apache.cassandra.auth.AuthKeyspace;
@@ -139,7 +138,8 @@ public class Cassandra311SystemAuthRoles implements SystemAuthRoles {
         return rows.result.isEmpty();
     }
 
-    public void createRole(String roleName, boolean superUser, Optional<String> defaultRoleMembership) {
+    public void createRole(String roleName, boolean superUser, String defaultRoleMembership)
+    {
         final CreateRoleStatement createStmt = (CreateRoleStatement) QueryProcessor.getStatement(format(CREATE_ROLE_STATEMENT_WITH_LOGIN,
                                                                                                         roleName,
                                                                                                         superUser),
@@ -149,13 +149,17 @@ public class Cassandra311SystemAuthRoles implements SystemAuthRoles {
                            QueryOptions.forInternalCalls(LOCAL_ONE, singletonList(ByteBufferUtil.bytes(roleName))),
                            System.nanoTime());
 
-        if (defaultRoleMembership.isPresent()) {
-            if (roleMissing(defaultRoleMembership.get())) {
-                logger.warn("Unable to add user to default role {} because it doesn't exist.", defaultRoleMembership.get());
-            } else {
-                logger.debug("Adding user {} to default role {}", roleName, defaultRoleMembership.get());
+        if (defaultRoleMembership != null)
+        {
+            if (roleMissing(defaultRoleMembership))
+            {
+                logger.warn("Unable to add user to default role {} because it doesn't exist.", defaultRoleMembership);
+            }
+            else
+            {
+                logger.debug("Adding user {} to default role {}", roleName, defaultRoleMembership);
                 final GrantRoleStatement grantRoleStmt = (GrantRoleStatement) QueryProcessor.getStatement(format(GRANT_ROLE_STATEMENT,
-                                                                                                                 defaultRoleMembership.get(),
+                                                                                                                 defaultRoleMembership,
                                                                                                                  roleName),
                                                                                                           getClientState()).statement;
 

--- a/cassandra-3.11/src/main/java/com/instaclustr/cassandra/ldap/auth/Cassandra311SystemAuthRoles.java
+++ b/cassandra-3.11/src/main/java/com/instaclustr/cassandra/ldap/auth/Cassandra311SystemAuthRoles.java
@@ -22,6 +22,7 @@ import static java.util.Collections.singletonList;
 import static org.apache.cassandra.db.ConsistencyLevel.LOCAL_ONE;
 
 import java.util.Collections;
+import java.util.Optional;
 
 import com.google.common.base.Function;
 import org.apache.cassandra.auth.AuthKeyspace;
@@ -33,6 +34,7 @@ import org.apache.cassandra.cql3.UntypedResultSet;
 import org.apache.cassandra.cql3.UntypedResultSet.Row;
 import org.apache.cassandra.cql3.statements.CreateRoleStatement;
 import org.apache.cassandra.cql3.statements.SelectStatement;
+import org.apache.cassandra.cql3.statements.GrantRoleStatement;
 import org.apache.cassandra.db.ConsistencyLevel;
 import org.apache.cassandra.db.marshal.UTF8Type;
 import org.apache.cassandra.exceptions.RequestExecutionException;
@@ -51,6 +53,8 @@ public class Cassandra311SystemAuthRoles implements SystemAuthRoles {
     public static final String SELECT_ROLE_STATEMENT = "SELECT role FROM %s.%s where role = ?";
 
     public static final String CREATE_ROLE_STATEMENT_WITH_LOGIN = "CREATE ROLE IF NOT EXISTS \"%s\" WITH LOGIN = true AND SUPERUSER = %s";
+
+    public static final String GRANT_ROLE_STATEMENT = "GRANT '%s' TO '%s'";
 
     private ClientState clientState;
 
@@ -135,7 +139,7 @@ public class Cassandra311SystemAuthRoles implements SystemAuthRoles {
         return rows.result.isEmpty();
     }
 
-    public void createRole(String roleName, boolean superUser) {
+    public void createRole(String roleName, boolean superUser, Optional<String> defaultRoleMembership) {
         final CreateRoleStatement createStmt = (CreateRoleStatement) QueryProcessor.getStatement(format(CREATE_ROLE_STATEMENT_WITH_LOGIN,
                                                                                                         roleName,
                                                                                                         superUser),
@@ -144,6 +148,22 @@ public class Cassandra311SystemAuthRoles implements SystemAuthRoles {
         createStmt.execute(new QueryState(getClientState()),
                            QueryOptions.forInternalCalls(LOCAL_ONE, singletonList(ByteBufferUtil.bytes(roleName))),
                            System.nanoTime());
+
+        if (defaultRoleMembership.isPresent()) {
+            if (roleMissing(defaultRoleMembership.get())) {
+                logger.warn("Unable to add user to default role {} because it doesn't exist.", defaultRoleMembership.get());
+            } else {
+                logger.debug("Adding user {} to default role {}", roleName, defaultRoleMembership.get());
+                final GrantRoleStatement grantRoleStmt = (GrantRoleStatement) QueryProcessor.getStatement(format(GRANT_ROLE_STATEMENT,
+                                                                                                                 defaultRoleMembership.get(),
+                                                                                                                 roleName),
+                                                                                                          getClientState()).statement;
+
+                grantRoleStmt.execute(new QueryState(getClientState()),
+                                      QueryOptions.forInternalCalls(LOCAL_ONE, singletonList(ByteBufferUtil.bytes(roleName))),
+                                      System.nanoTime());
+            }
+        }
     }
 
     @Override

--- a/cassandra-3.11/src/test/java/com/instaclustr/cassandra/ldap/auth/AbstractLDAPTest.java
+++ b/cassandra-3.11/src/test/java/com/instaclustr/cassandra/ldap/auth/AbstractLDAPTest.java
@@ -59,6 +59,14 @@ import static org.testng.Assert.*;
 public abstract class AbstractLDAPTest {
 
     private static final Logger logger = LoggerFactory.getLogger(AbstractLDAPTest.class);
+    private static final String cassandraAdminUser = "cassandra";
+    private static final String cassandraAdminPassword = "cassandra";
+    private static final String cassandraDataCenter1 = "datacenter1";
+    private static final String testUserName = "bill";
+    private static final String testUserPassword = "test";
+    private static final String testUserDn = "cn=bill,dc=example,dc=org";
+    private static final String defaultRoleName = "default_role";
+    private static final String basicQuery = "SELECT * FROM system.local;";
 
     protected void testLDAPinternal() throws Exception {
         try (final GenericContainer ldapContainer = prepareLdapContainer();
@@ -67,20 +75,62 @@ public abstract class AbstractLDAPTest {
             context.start();
 
             context.execute(context.firstNode,
-                    "cassandra",
-                    "cassandra",
-                    "ALTER KEYSPACE system_auth WITH replication = {'class': 'NetworkTopologyStrategy', 'datacenter1': 1, 'datacenter2':1};", "datacenter1", false);
+                    cassandraAdminUser,
+                    cassandraAdminPassword,
+                    "ALTER KEYSPACE system_auth WITH replication = {'class': 'NetworkTopologyStrategy', 'datacenter1': 1, 'datacenter2':1};", cassandraDataCenter1, false);
 
             logger.info("[first node]: login via cassandra");
-            context.execute(context.firstNode, "cassandra", "cassandra", "select * from system_auth.roles", "datacenter1", true);
+            context.execute(context.firstNode, cassandraAdminUser, cassandraAdminPassword, "select * from system_auth.roles", cassandraDataCenter1, true);
             logger.info("[first node]: login bill");
-            context.execute(context.firstNode, "bill", "test", "select * from system.local", "datacenter1", true);
+            context.execute(context.firstNode, testUserName, testUserPassword, basicQuery, cassandraDataCenter1, true);
 
             logger.info("[second node]: login bill");
-            context.execute(context.secondNode, "bill", "test", "select * from system.local", "datacenter2", true);
+            context.execute(context.secondNode, testUserName, testUserPassword, basicQuery, "datacenter2", true);
+
+            testDefaultRoleMembership(ldapContainer, context);
         } catch (final Exception ex) {
             fail("Exception occurred!", ex);
         }
+    }
+
+    protected void testDefaultRoleMembership(GenericContainer ldapContainer, CassandraClusterContext context) throws Exception {
+        // Create the default role
+        context.simpleExecute(
+            context.firstNode,
+            cassandraAdminUser,
+            cassandraAdminPassword,
+            String.format("CREATE ROLE '%s';", defaultRoleName),
+            cassandraDataCenter1
+        );
+
+        // Delete the user if it already exists
+        context.simpleExecute(
+            context.firstNode,
+            cassandraAdminUser,
+            cassandraAdminPassword,
+            String.format("DROP ROLE IF EXISTS '%s';", testUserDn),
+            cassandraDataCenter1
+        );
+
+        // Simulate a Logon as the user
+        context.simpleExecute(
+            context.firstNode,
+            testUserName,
+            testUserPassword,
+            basicQuery,
+            cassandraDataCenter1
+        );
+
+        // Check that the default role has been added to the user
+        assertTrue(
+            context.simpleExecute(
+                context.firstNode,
+                cassandraAdminUser,
+                cassandraAdminPassword,
+                String.format("LIST ROLES OF '%s';", testUserDn),
+                cassandraDataCenter1
+            ).all().stream().anyMatch(row -> row.getString("role").equals(defaultRoleName))
+        );
     }
 
     public abstract String getCassandraVersion();
@@ -153,6 +203,22 @@ public abstract class AbstractLDAPTest {
             }
         }
 
+        public synchronized ResultSet simpleExecute(
+            Cassandra node,
+            String username,
+            String password,
+            String query,
+            String dc
+        ) {
+            try (final Session session = Cluster.builder()
+                    .addContactPoint(node.getSettings().getAddress().getHostAddress())
+                    .withLoadBalancingPolicy(new DCAwareRoundRobinPolicy.Builder().withLocalDc(dc).build())
+                    .withAuthProvider(new PlainTextAuthProvider(username, password))
+                    .build().connect()) {
+                return session.execute(query);
+            }
+        }
+
         public void waitForClosedPort(String hostname, int port) {
             await().timeout(FIVE_MINUTES).until(() ->
             {
@@ -203,6 +269,7 @@ public abstract class AbstractLDAPTest {
                         add(addResource(new ClassPathResource(node + ".yaml"), "conf/cassandra.yaml"));
                     }
                     add(addResource(new ClassPathResource(node + "-rackdc.properties"), "conf/cassandra-rackdc.properties"));
+                    add(addResource(new ClassPathResource("logback.xml"), "conf/logback.xml"));
                     for (Path pluginJar : pluginJars) {
                         add(addResource(new FileSystemResource(pluginJar), "lib/" + pluginJar.getFileName().toString()));
                     }

--- a/cassandra-3.11/src/test/java/com/instaclustr/cassandra/ldap/auth/AbstractLDAPTest.java
+++ b/cassandra-3.11/src/test/java/com/instaclustr/cassandra/ldap/auth/AbstractLDAPTest.java
@@ -93,7 +93,8 @@ public abstract class AbstractLDAPTest {
         }
     }
 
-    protected void testDefaultRoleMembership(GenericContainer ldapContainer, CassandraClusterContext context) throws Exception {
+    protected void testDefaultRoleMembership(GenericContainer ldapContainer, CassandraClusterContext context) throws Exception
+    {
         // Create the default role
         context.simpleExecute(
             context.firstNode,

--- a/cassandra-3.11/src/test/java/com/instaclustr/cassandra/ldap/auth/AbstractLDAPTest.java
+++ b/cassandra-3.11/src/test/java/com/instaclustr/cassandra/ldap/auth/AbstractLDAPTest.java
@@ -269,7 +269,6 @@ public abstract class AbstractLDAPTest {
                         add(addResource(new ClassPathResource(node + ".yaml"), "conf/cassandra.yaml"));
                     }
                     add(addResource(new ClassPathResource(node + "-rackdc.properties"), "conf/cassandra-rackdc.properties"));
-                    add(addResource(new ClassPathResource("logback.xml"), "conf/logback.xml"));
                     for (Path pluginJar : pluginJars) {
                         add(addResource(new FileSystemResource(pluginJar), "lib/" + pluginJar.getFileName().toString()));
                     }

--- a/cassandra-3.11/src/test/java/com/instaclustr/cassandra/ldap/auth/AbstractLDAPTest.java
+++ b/cassandra-3.11/src/test/java/com/instaclustr/cassandra/ldap/auth/AbstractLDAPTest.java
@@ -204,13 +204,12 @@ public abstract class AbstractLDAPTest {
             }
         }
 
-        public synchronized ResultSet simpleExecute(
-            Cassandra node,
-            String username,
-            String password,
-            String query,
-            String dc
-        ) {
+        public synchronized ResultSet simpleExecute(Cassandra node,
+                                                    String username,
+                                                    String password,
+                                                    String query,
+                                                    String dc)
+        {
             try (final Session session = Cluster.builder()
                     .addContactPoint(node.getSettings().getAddress().getHostAddress())
                     .withLoadBalancingPolicy(new DCAwareRoundRobinPolicy.Builder().withLocalDc(dc).build())

--- a/cassandra-3.11/src/test/java/com/instaclustr/cassandra/ldap/auth/Cassandra311LDAPIntegrationTest.java
+++ b/cassandra-3.11/src/test/java/com/instaclustr/cassandra/ldap/auth/Cassandra311LDAPIntegrationTest.java
@@ -10,7 +10,7 @@ public class Cassandra311LDAPIntegrationTest extends AbstractLDAPTest {
 
     @Override
     public String getImplementationGAV() {
-        return "com.instaclustr:cassandra-ldap-" + getCassandraVersion() + ":1.0.0";
+        return "com.instaclustr:cassandra-ldap-" + getCassandraVersion() + ":1.1.0";
     }
 
     @Test

--- a/cassandra-4.0/pom.xml
+++ b/cassandra-4.0/pom.xml
@@ -11,7 +11,7 @@
     </parent>
 
     <artifactId>cassandra-ldap-4.0.7</artifactId>
-    <version>1.0.0</version>
+    <version>1.1.0</version>
 
     <name>Cassandra LDAP Authenticator for Cassandra 4.0</name>
     <description>Pluggable LDAP authentication implementation for Apache Cassandra 4.0</description>

--- a/cassandra-4.0/src/main/java/com/instaclustr/cassandra/ldap/auth/Cassandra40SystemAuthRoles.java
+++ b/cassandra-4.0/src/main/java/com/instaclustr/cassandra/ldap/auth/Cassandra40SystemAuthRoles.java
@@ -22,6 +22,7 @@ import static java.util.Collections.singletonList;
 import static org.apache.cassandra.db.ConsistencyLevel.LOCAL_ONE;
 
 import java.util.Collections;
+import java.util.Optional;
 
 import com.google.common.base.Function;
 import org.apache.cassandra.auth.AuthKeyspace;
@@ -33,6 +34,7 @@ import org.apache.cassandra.cql3.UntypedResultSet;
 import org.apache.cassandra.cql3.UntypedResultSet.Row;
 import org.apache.cassandra.cql3.statements.CreateRoleStatement;
 import org.apache.cassandra.cql3.statements.SelectStatement;
+import org.apache.cassandra.cql3.statements.GrantRoleStatement;
 import org.apache.cassandra.db.ConsistencyLevel;
 import org.apache.cassandra.db.marshal.UTF8Type;
 import org.apache.cassandra.exceptions.RequestExecutionException;
@@ -52,6 +54,8 @@ public class Cassandra40SystemAuthRoles implements SystemAuthRoles
     public static final String SELECT_ROLE_STATEMENT = "SELECT role FROM %s.%s where role = ?";
 
     public static final String CREATE_ROLE_STATEMENT_WITH_LOGIN = "CREATE ROLE IF NOT EXISTS \"%s\" WITH LOGIN = true AND SUPERUSER = %s";
+
+    public static final String GRANT_ROLE_STATEMENT = "GRANT '%s' TO '%s'";
 
     private ClientState clientState;
 
@@ -136,7 +140,7 @@ public class Cassandra40SystemAuthRoles implements SystemAuthRoles
         return rows.result.isEmpty();
     }
 
-    public void createRole(String roleName, boolean superUser) {
+    public void createRole(String roleName, boolean superUser, Optional<String> defaultRoleMembership) {
         final CreateRoleStatement createStmt = (CreateRoleStatement) QueryProcessor.getStatement(format(CREATE_ROLE_STATEMENT_WITH_LOGIN,
                                                                                                         roleName,
                                                                                                         superUser),
@@ -145,6 +149,22 @@ public class Cassandra40SystemAuthRoles implements SystemAuthRoles
         createStmt.execute(new QueryState(getClientState()),
                            QueryOptions.forInternalCalls(LOCAL_ONE, singletonList(ByteBufferUtil.bytes(roleName))),
                            System.nanoTime());
+
+        if (defaultRoleMembership.isPresent()) {
+            if (roleMissing(defaultRoleMembership.get())) {
+                logger.warn("Unable to add user to default role {} because it doesn't exist.", defaultRoleMembership.get());
+            } else {
+                logger.debug("Adding user {} to default role {}", roleName, defaultRoleMembership.get());
+                final GrantRoleStatement grantRoleStmt = (GrantRoleStatement) QueryProcessor.getStatement(format(GRANT_ROLE_STATEMENT,
+                                                                                                                 defaultRoleMembership.get(),
+                                                                                                                 roleName),
+                                                                                                          getClientState());
+
+                grantRoleStmt.execute(new QueryState(getClientState()),
+                                      QueryOptions.forInternalCalls(LOCAL_ONE, singletonList(ByteBufferUtil.bytes(roleName))),
+                                      System.nanoTime());
+            }
+        }
     }
 
     @Override

--- a/cassandra-4.0/src/main/java/com/instaclustr/cassandra/ldap/auth/Cassandra40SystemAuthRoles.java
+++ b/cassandra-4.0/src/main/java/com/instaclustr/cassandra/ldap/auth/Cassandra40SystemAuthRoles.java
@@ -22,7 +22,6 @@ import static java.util.Collections.singletonList;
 import static org.apache.cassandra.db.ConsistencyLevel.LOCAL_ONE;
 
 import java.util.Collections;
-import java.util.Optional;
 
 import com.google.common.base.Function;
 import org.apache.cassandra.auth.AuthKeyspace;
@@ -140,7 +139,8 @@ public class Cassandra40SystemAuthRoles implements SystemAuthRoles
         return rows.result.isEmpty();
     }
 
-    public void createRole(String roleName, boolean superUser, Optional<String> defaultRoleMembership) {
+    public void createRole(String roleName, boolean superUser, String defaultRoleMembership)
+    {
         final CreateRoleStatement createStmt = (CreateRoleStatement) QueryProcessor.getStatement(format(CREATE_ROLE_STATEMENT_WITH_LOGIN,
                                                                                                         roleName,
                                                                                                         superUser),
@@ -150,13 +150,17 @@ public class Cassandra40SystemAuthRoles implements SystemAuthRoles
                            QueryOptions.forInternalCalls(LOCAL_ONE, singletonList(ByteBufferUtil.bytes(roleName))),
                            System.nanoTime());
 
-        if (defaultRoleMembership.isPresent()) {
-            if (roleMissing(defaultRoleMembership.get())) {
-                logger.warn("Unable to add user to default role {} because it doesn't exist.", defaultRoleMembership.get());
-            } else {
-                logger.debug("Adding user {} to default role {}", roleName, defaultRoleMembership.get());
+        if (defaultRoleMembership != null)
+        {
+            if (roleMissing(defaultRoleMembership))
+            {
+                logger.warn("Unable to add user to default role {} because it doesn't exist.", defaultRoleMembership);
+            }
+            else
+            {
+                logger.debug("Adding user {} to default role {}", roleName, defaultRoleMembership);
                 final GrantRoleStatement grantRoleStmt = (GrantRoleStatement) QueryProcessor.getStatement(format(GRANT_ROLE_STATEMENT,
-                                                                                                                 defaultRoleMembership.get(),
+                                                                                                                 defaultRoleMembership,
                                                                                                                  roleName),
                                                                                                           getClientState());
 

--- a/cassandra-4.0/src/test/java/com/instaclustr/cassandra/ldap/auth/AbstractLDAPTest.java
+++ b/cassandra-4.0/src/test/java/com/instaclustr/cassandra/ldap/auth/AbstractLDAPTest.java
@@ -93,7 +93,8 @@ public abstract class AbstractLDAPTest {
         }
     }
 
-    protected void testDefaultRoleMembership(GenericContainer ldapContainer, CassandraClusterContext context) throws Exception {
+    protected void testDefaultRoleMembership(GenericContainer ldapContainer, CassandraClusterContext context) throws Exception
+    {
         // Create the default role
         context.simpleExecute(
             context.firstNode,

--- a/cassandra-4.0/src/test/java/com/instaclustr/cassandra/ldap/auth/AbstractLDAPTest.java
+++ b/cassandra-4.0/src/test/java/com/instaclustr/cassandra/ldap/auth/AbstractLDAPTest.java
@@ -59,6 +59,14 @@ import static org.testng.Assert.*;
 public abstract class AbstractLDAPTest {
 
     private static final Logger logger = LoggerFactory.getLogger(AbstractLDAPTest.class);
+    private static final String cassandraAdminUser = "cassandra";
+    private static final String cassandraAdminPassword = "cassandra";
+    private static final String cassandraDataCenter1 = "datacenter1";
+    private static final String testUserName = "bill";
+    private static final String testUserPassword = "test";
+    private static final String testUserDn = "cn=bill,dc=example,dc=org";
+    private static final String defaultRoleName = "default_role";
+    private static final String basicQuery = "SELECT * FROM system.local;";
 
     protected void testLDAPinternal() throws Exception {
         try (final GenericContainer ldapContainer = prepareLdapContainer();
@@ -67,20 +75,62 @@ public abstract class AbstractLDAPTest {
             context.start();
 
             context.execute(context.firstNode,
-                    "cassandra",
-                    "cassandra",
-                    "ALTER KEYSPACE system_auth WITH replication = {'class': 'NetworkTopologyStrategy', 'datacenter1': 1, 'datacenter2':1};", "datacenter1", false);
+                    cassandraAdminUser,
+                    cassandraAdminPassword,
+                    "ALTER KEYSPACE system_auth WITH replication = {'class': 'NetworkTopologyStrategy', 'datacenter1': 1, 'datacenter2':1};", cassandraDataCenter1, false);
 
             logger.info("[first node]: login via cassandra");
-            context.execute(context.firstNode, "cassandra", "cassandra", "select * from system_auth.roles", "datacenter1", true);
+            context.execute(context.firstNode, cassandraAdminUser, cassandraAdminPassword, "select * from system_auth.roles", cassandraDataCenter1, true);
             logger.info("[first node]: login bill");
-            context.execute(context.firstNode, "bill", "test", "select * from system.local", "datacenter1", true);
+            context.execute(context.firstNode, testUserName, testUserPassword, basicQuery, cassandraDataCenter1, true);
 
             logger.info("[second node]: login bill");
-            context.execute(context.secondNode, "bill", "test", "select * from system.local", "datacenter2", true);
+            context.execute(context.secondNode, testUserName, testUserPassword, basicQuery, "datacenter2", true);
+
+            testDefaultRoleMembership(ldapContainer, context);
         } catch (final Exception ex) {
             fail("Exception occurred!", ex);
         }
+    }
+
+    protected void testDefaultRoleMembership(GenericContainer ldapContainer, CassandraClusterContext context) throws Exception {
+        // Create the default role
+        context.simpleExecute(
+            context.firstNode,
+            cassandraAdminUser,
+            cassandraAdminPassword,
+            String.format("CREATE ROLE '%s';", defaultRoleName),
+            cassandraDataCenter1
+        );
+
+        // Delete the user if it already exists
+        context.simpleExecute(
+            context.firstNode,
+            cassandraAdminUser,
+            cassandraAdminPassword,
+            String.format("DROP ROLE IF EXISTS '%s';", testUserDn),
+            cassandraDataCenter1
+        );
+
+        // Simulate a Logon as the user
+        context.simpleExecute(
+            context.firstNode,
+            testUserName,
+            testUserPassword,
+            basicQuery,
+            cassandraDataCenter1
+        );
+
+        // Check that the default role has been added to the user
+        assertTrue(
+            context.simpleExecute(
+                context.firstNode,
+                cassandraAdminUser,
+                cassandraAdminPassword,
+                String.format("LIST ROLES OF '%s';", testUserDn),
+                cassandraDataCenter1
+            ).all().stream().anyMatch(row -> row.getString("role").equals(defaultRoleName))
+        );
     }
 
     public abstract String getCassandraVersion();
@@ -150,6 +200,22 @@ public abstract class AbstractLDAPTest {
                 }
             } catch (final Exception ex) {
                 fail("Failed to execute a request!", ex);
+            }
+        }
+
+        public synchronized ResultSet simpleExecute(
+            Cassandra node,
+            String username,
+            String password,
+            String query,
+            String dc
+        ) {
+            try (final Session session = Cluster.builder()
+                    .addContactPoint(node.getSettings().getAddress().getHostAddress())
+                    .withLoadBalancingPolicy(new DCAwareRoundRobinPolicy.Builder().withLocalDc(dc).build())
+                    .withAuthProvider(new PlainTextAuthProvider(username, password))
+                    .build().connect()) {
+                return session.execute(query);
             }
         }
 

--- a/cassandra-4.0/src/test/java/com/instaclustr/cassandra/ldap/auth/AbstractLDAPTest.java
+++ b/cassandra-4.0/src/test/java/com/instaclustr/cassandra/ldap/auth/AbstractLDAPTest.java
@@ -204,13 +204,12 @@ public abstract class AbstractLDAPTest {
             }
         }
 
-        public synchronized ResultSet simpleExecute(
-            Cassandra node,
-            String username,
-            String password,
-            String query,
-            String dc
-        ) {
+        public synchronized ResultSet simpleExecute(Cassandra node,
+                                                    String username,
+                                                    String password,
+                                                    String query,
+                                                    String dc)
+        {
             try (final Session session = Cluster.builder()
                     .addContactPoint(node.getSettings().getAddress().getHostAddress())
                     .withLoadBalancingPolicy(new DCAwareRoundRobinPolicy.Builder().withLocalDc(dc).build())

--- a/cassandra-4.0/src/test/java/com/instaclustr/cassandra/ldap/auth/Cassandra40LDAPIntegrationTest.java
+++ b/cassandra-4.0/src/test/java/com/instaclustr/cassandra/ldap/auth/Cassandra40LDAPIntegrationTest.java
@@ -10,7 +10,7 @@ public class Cassandra40LDAPIntegrationTest extends AbstractLDAPTest {
 
     @Override
     public String getImplementationGAV() {
-        return "com.instaclustr:cassandra-ldap-" + getCassandraVersion() + ":1.0.0";
+        return "com.instaclustr:cassandra-ldap-" + getCassandraVersion() + ":1.1.0";
     }
 
     @Test

--- a/cassandra-4.1/pom.xml
+++ b/cassandra-4.1/pom.xml
@@ -11,7 +11,7 @@
     </parent>
 
     <artifactId>cassandra-ldap-4.1.0</artifactId>
-    <version>1.0.0</version>
+    <version>1.1.0</version>
 
     <name>Cassandra LDAP Authenticator for Cassandra 4.1</name>
     <description>Pluggable LDAP authentication implementation for Apache Cassandra 4.1</description>

--- a/cassandra-4.1/src/main/java/com/instaclustr/cassandra/ldap/auth/Cassandra41SystemAuthRoles.java
+++ b/cassandra-4.1/src/main/java/com/instaclustr/cassandra/ldap/auth/Cassandra41SystemAuthRoles.java
@@ -22,6 +22,7 @@ import static java.util.Collections.singletonList;
 import static org.apache.cassandra.db.ConsistencyLevel.LOCAL_ONE;
 
 import java.util.Collections;
+import java.util.Optional;
 
 import com.google.common.base.Function;
 import org.apache.cassandra.auth.AuthKeyspace;
@@ -33,6 +34,7 @@ import org.apache.cassandra.cql3.UntypedResultSet;
 import org.apache.cassandra.cql3.UntypedResultSet.Row;
 import org.apache.cassandra.cql3.statements.CreateRoleStatement;
 import org.apache.cassandra.cql3.statements.SelectStatement;
+import org.apache.cassandra.cql3.statements.GrantRoleStatement;
 import org.apache.cassandra.db.ConsistencyLevel;
 import org.apache.cassandra.db.marshal.UTF8Type;
 import org.apache.cassandra.exceptions.RequestExecutionException;
@@ -52,6 +54,8 @@ public class Cassandra41SystemAuthRoles implements SystemAuthRoles
     public static final String SELECT_ROLE_STATEMENT = "SELECT role FROM %s.%s where role = ?";
 
     public static final String CREATE_ROLE_STATEMENT_WITH_LOGIN = "CREATE ROLE IF NOT EXISTS \"%s\" WITH LOGIN = true AND SUPERUSER = %s";
+
+    public static final String GRANT_ROLE_STATEMENT = "GRANT '%s' TO '%s'";
 
     private ClientState clientState;
 
@@ -136,7 +140,7 @@ public class Cassandra41SystemAuthRoles implements SystemAuthRoles
         return rows.result.isEmpty();
     }
 
-    public void createRole(String roleName, boolean superUser) {
+    public void createRole(String roleName, boolean superUser, Optional<String> defaultRoleMembership) {
         final CreateRoleStatement createStmt = (CreateRoleStatement) QueryProcessor.getStatement(format(CREATE_ROLE_STATEMENT_WITH_LOGIN,
                                                                                                         roleName,
                                                                                                         superUser),
@@ -145,6 +149,22 @@ public class Cassandra41SystemAuthRoles implements SystemAuthRoles
         createStmt.execute(new QueryState(getClientState()),
                            QueryOptions.forInternalCalls(LOCAL_ONE, singletonList(ByteBufferUtil.bytes(roleName))),
                            System.nanoTime());
+
+        if (defaultRoleMembership.isPresent()) {
+            if (roleMissing(defaultRoleMembership.get())) {
+                logger.warn("Unable to add user to default role {} because it doesn't exist.", defaultRoleMembership.get());
+            } else {
+                logger.debug("Adding user {} to default role {}", roleName, defaultRoleMembership.get());
+                final GrantRoleStatement grantRoleStmt = (GrantRoleStatement) QueryProcessor.getStatement(format(GRANT_ROLE_STATEMENT,
+                                                                                                                 defaultRoleMembership.get(),
+                                                                                                                 roleName),
+                                                                                                          getClientState());
+
+                grantRoleStmt.execute(new QueryState(getClientState()),
+                                      QueryOptions.forInternalCalls(LOCAL_ONE, singletonList(ByteBufferUtil.bytes(roleName))),
+                                      System.nanoTime());
+            }
+        }
     }
 
     @Override

--- a/cassandra-4.1/src/main/java/com/instaclustr/cassandra/ldap/auth/Cassandra41SystemAuthRoles.java
+++ b/cassandra-4.1/src/main/java/com/instaclustr/cassandra/ldap/auth/Cassandra41SystemAuthRoles.java
@@ -22,7 +22,6 @@ import static java.util.Collections.singletonList;
 import static org.apache.cassandra.db.ConsistencyLevel.LOCAL_ONE;
 
 import java.util.Collections;
-import java.util.Optional;
 
 import com.google.common.base.Function;
 import org.apache.cassandra.auth.AuthKeyspace;
@@ -140,7 +139,8 @@ public class Cassandra41SystemAuthRoles implements SystemAuthRoles
         return rows.result.isEmpty();
     }
 
-    public void createRole(String roleName, boolean superUser, Optional<String> defaultRoleMembership) {
+    public void createRole(String roleName, boolean superUser, String defaultRoleMembership)
+    {
         final CreateRoleStatement createStmt = (CreateRoleStatement) QueryProcessor.getStatement(format(CREATE_ROLE_STATEMENT_WITH_LOGIN,
                                                                                                         roleName,
                                                                                                         superUser),
@@ -150,13 +150,17 @@ public class Cassandra41SystemAuthRoles implements SystemAuthRoles
                            QueryOptions.forInternalCalls(LOCAL_ONE, singletonList(ByteBufferUtil.bytes(roleName))),
                            System.nanoTime());
 
-        if (defaultRoleMembership.isPresent()) {
-            if (roleMissing(defaultRoleMembership.get())) {
-                logger.warn("Unable to add user to default role {} because it doesn't exist.", defaultRoleMembership.get());
-            } else {
-                logger.debug("Adding user {} to default role {}", roleName, defaultRoleMembership.get());
+        if (defaultRoleMembership != null)
+        {
+            if (roleMissing(defaultRoleMembership))
+            {
+                logger.warn("Unable to add user to default role {} because it doesn't exist.", defaultRoleMembership);
+            }
+            else
+            {
+                logger.debug("Adding user {} to default role {}", roleName, defaultRoleMembership);
                 final GrantRoleStatement grantRoleStmt = (GrantRoleStatement) QueryProcessor.getStatement(format(GRANT_ROLE_STATEMENT,
-                                                                                                                 defaultRoleMembership.get(),
+                                                                                                                 defaultRoleMembership,
                                                                                                                  roleName),
                                                                                                           getClientState());
 

--- a/cassandra-4.1/src/test/java/com/instaclustr/cassandra/ldap/auth/AbstractLDAPTest.java
+++ b/cassandra-4.1/src/test/java/com/instaclustr/cassandra/ldap/auth/AbstractLDAPTest.java
@@ -93,7 +93,8 @@ public abstract class AbstractLDAPTest {
         }
     }
 
-    protected void testDefaultRoleMembership(GenericContainer ldapContainer, CassandraClusterContext context) throws Exception {
+    protected void testDefaultRoleMembership(GenericContainer ldapContainer, CassandraClusterContext context) throws Exception
+    {
         // Create the default role
         context.simpleExecute(
             context.firstNode,

--- a/cassandra-4.1/src/test/java/com/instaclustr/cassandra/ldap/auth/AbstractLDAPTest.java
+++ b/cassandra-4.1/src/test/java/com/instaclustr/cassandra/ldap/auth/AbstractLDAPTest.java
@@ -59,6 +59,14 @@ import static org.testng.Assert.*;
 public abstract class AbstractLDAPTest {
 
     private static final Logger logger = LoggerFactory.getLogger(AbstractLDAPTest.class);
+    private static final String cassandraAdminUser = "cassandra";
+    private static final String cassandraAdminPassword = "cassandra";
+    private static final String cassandraDataCenter1 = "datacenter1";
+    private static final String testUserName = "bill";
+    private static final String testUserPassword = "test";
+    private static final String testUserDn = "cn=bill,dc=example,dc=org";
+    private static final String defaultRoleName = "default_role";
+    private static final String basicQuery = "SELECT * FROM system.local;";
 
     protected void testLDAPinternal() throws Exception {
         try (final GenericContainer ldapContainer = prepareLdapContainer();
@@ -67,20 +75,62 @@ public abstract class AbstractLDAPTest {
             context.start();
 
             context.execute(context.firstNode,
-                    "cassandra",
-                    "cassandra",
-                    "ALTER KEYSPACE system_auth WITH replication = {'class': 'NetworkTopologyStrategy', 'datacenter1': 1, 'datacenter2':1};", "datacenter1", false);
+                    cassandraAdminUser,
+                    cassandraAdminPassword,
+                    "ALTER KEYSPACE system_auth WITH replication = {'class': 'NetworkTopologyStrategy', 'datacenter1': 1, 'datacenter2':1};", cassandraDataCenter1, false);
 
             logger.info("[first node]: login via cassandra");
-            context.execute(context.firstNode, "cassandra", "cassandra", "select * from system_auth.roles", "datacenter1", true);
+            context.execute(context.firstNode, cassandraAdminUser, cassandraAdminPassword, "select * from system_auth.roles", cassandraDataCenter1, true);
             logger.info("[first node]: login bill");
-            context.execute(context.firstNode, "bill", "test", "select * from system.local", "datacenter1", true);
+            context.execute(context.firstNode, testUserName, testUserPassword, basicQuery, cassandraDataCenter1, true);
 
             logger.info("[second node]: login bill");
-            context.execute(context.secondNode, "bill", "test", "select * from system.local", "datacenter2", true);
+            context.execute(context.secondNode, testUserName, testUserPassword, basicQuery, "datacenter2", true);
+
+            testDefaultRoleMembership(ldapContainer, context);
         } catch (final Exception ex) {
             fail("Exception occurred!", ex);
         }
+    }
+
+    protected void testDefaultRoleMembership(GenericContainer ldapContainer, CassandraClusterContext context) throws Exception {
+        // Create the default role
+        context.simpleExecute(
+            context.firstNode,
+            cassandraAdminUser,
+            cassandraAdminPassword,
+            String.format("CREATE ROLE '%s';", defaultRoleName),
+            cassandraDataCenter1
+        );
+
+        // Delete the user if it already exists
+        context.simpleExecute(
+            context.firstNode,
+            cassandraAdminUser,
+            cassandraAdminPassword,
+            String.format("DROP ROLE IF EXISTS '%s';", testUserDn),
+            cassandraDataCenter1
+        );
+
+        // Simulate a Logon as the user
+        context.simpleExecute(
+            context.firstNode,
+            testUserName,
+            testUserPassword,
+            basicQuery,
+            cassandraDataCenter1
+        );
+
+        // Check that the default role has been added to the user
+        assertTrue(
+            context.simpleExecute(
+                context.firstNode,
+                cassandraAdminUser,
+                cassandraAdminPassword,
+                String.format("LIST ROLES OF '%s';", testUserDn),
+                cassandraDataCenter1
+            ).all().stream().anyMatch(row -> row.getString("role").equals(defaultRoleName))
+        );
     }
 
     public abstract String getCassandraVersion();
@@ -150,6 +200,22 @@ public abstract class AbstractLDAPTest {
                 }
             } catch (final Exception ex) {
                 fail("Failed to execute a request!", ex);
+            }
+        }
+
+        public synchronized ResultSet simpleExecute(
+            Cassandra node,
+            String username,
+            String password,
+            String query,
+            String dc
+        ) {
+            try (final Session session = Cluster.builder()
+                    .addContactPoint(node.getSettings().getAddress().getHostAddress())
+                    .withLoadBalancingPolicy(new DCAwareRoundRobinPolicy.Builder().withLocalDc(dc).build())
+                    .withAuthProvider(new PlainTextAuthProvider(username, password))
+                    .build().connect()) {
+                return session.execute(query);
             }
         }
 

--- a/cassandra-4.1/src/test/java/com/instaclustr/cassandra/ldap/auth/AbstractLDAPTest.java
+++ b/cassandra-4.1/src/test/java/com/instaclustr/cassandra/ldap/auth/AbstractLDAPTest.java
@@ -204,13 +204,12 @@ public abstract class AbstractLDAPTest {
             }
         }
 
-        public synchronized ResultSet simpleExecute(
-            Cassandra node,
-            String username,
-            String password,
-            String query,
-            String dc
-        ) {
+        public synchronized ResultSet simpleExecute(Cassandra node,
+                                                    String username,
+                                                    String password,
+                                                    String query,
+                                                    String dc)
+        {
             try (final Session session = Cluster.builder()
                     .addContactPoint(node.getSettings().getAddress().getHostAddress())
                     .withLoadBalancingPolicy(new DCAwareRoundRobinPolicy.Builder().withLocalDc(dc).build())

--- a/cassandra-4.1/src/test/java/com/instaclustr/cassandra/ldap/auth/Cassandra41LDAPIntegrationTest.java
+++ b/cassandra-4.1/src/test/java/com/instaclustr/cassandra/ldap/auth/Cassandra41LDAPIntegrationTest.java
@@ -10,7 +10,7 @@ public class Cassandra41LDAPIntegrationTest extends AbstractLDAPTest {
 
     @Override
     public String getImplementationGAV() {
-        return "com.instaclustr:cassandra-ldap-" + getCassandraVersion() + ":1.0.0";
+        return "com.instaclustr:cassandra-ldap-" + getCassandraVersion() + ":1.1.0";
     }
 
     @Test

--- a/conf/ldap.properties
+++ b/conf/ldap.properties
@@ -27,3 +27,6 @@ filter_template: (cn=%s)
 
 # consistency level to use for retrieval of a role to check if it can log in - defaults to LOCAL_ONE
 #consistency_for_role: LOCAL_ONE
+
+# Default role for new users to be added to
+default_role_membership: default_role


### PR DESCRIPTION
This PR adds a configuration option `default_role_membership`, which causes new LDAP users to be added to an existing Cassandra role when they first log in. This way they can be granted a default permission set.

When the configuration option is not set, there is no change to existing behaviour.

There's quite a lot of code duplication here because I didn't want to deviate from the patterns already followed in the project.

@smiklosovic let me know if you have any concerns